### PR TITLE
Parse images in html markdown block

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Source plugin for pulling documents into Gatsby-v4 from the Strapi-v4 graphql AP
 - [x] Relationships with other collection types
 - [x] Gatsby Cloud CMS previews & incremental builds
 - [x] Build caching and only fetching changes since last build
-- [x] Support for images in markdown fields
+- [x] Support for images in markdown / richtext fields
 
 ## 🚀 Installing the plugin
 
@@ -46,8 +46,8 @@ plugins: [
       apiURL: 'http://localhost:1337',
       collectionTypes: ['Article', 'User'],
       singleTypes: ['Home Page', 'Contact'],
-      // Extract images from markdown fields.
-      markdownImages: {
+      // Extract images from markdown / richtext fields.
+      inlineImages: {
         typesToParse: {
           Article: ['body'],
           ComponentBlockBody: ['text'],
@@ -172,9 +172,9 @@ To query images you can do the following:
 }
 ```
 
-To query markdown images for a markdown field named "text" you can do the following:
+To query inline images for a markdown / richtext field named "text" you can do the following:
 
-> To replace in markdown use the base returned from the file and create a custom renderer to match the url on the image with the base.
+> To replace in markdown / richtext use the base returned from the file and create a custom renderer to match the url on the image with the base.
 
 ```graphql
 {

--- a/build-types.js
+++ b/build-types.js
@@ -10,7 +10,7 @@ const {
   isListType,
 } = require('./helpers');
 
-const getTypeDefs = (typeNames, typeMap, schema, entityTypeMap, markdownImages) => {
+const getTypeDefs = (typeNames, typeMap, schema, entityTypeMap, inlineImages) => {
   const typeDefs = {};
   const foundTypes = [];
   for (let typeName of typeNames) {
@@ -93,7 +93,7 @@ const getTypeDefs = (typeNames, typeMap, schema, entityTypeMap, markdownImages) 
                 },
               },
             },
-            ...(markdownImages?.[type.name] || []).reduce((acc, field) => {
+            ...(inlineImages?.[type.name] || []).reduce((acc, field) => {
               return {
                 ...acc,
                 [`${field}_images`]: {
@@ -137,7 +137,7 @@ module.exports = async (pluginOptions, schema) => {
   const entityTypes = getEntityTypes(pluginOptions);
   const entityTypeMap = getTypeMap(entityTypes);
   const typeMap = await getTypesMap(pluginOptions);
-  const markdownImages = pluginOptions?.markdownImages?.typesToParse;
-  const result = getTypeDefs(entityTypes, typeMap, schema, entityTypeMap, markdownImages);
+  const inlineImages = pluginOptions?.inlineImages?.typesToParse;
+  const result = getTypeDefs(entityTypes, typeMap, schema, entityTypeMap, inlineImages);
   return Object.values(result);
 };

--- a/helpers.js
+++ b/helpers.js
@@ -117,6 +117,11 @@ ${JSON.stringify(variables, null, 2)}
 
 const extractFiles = (text, apiURL) => {
   const files = [];
+
+  if (!text) {
+    return files;
+  }
+
   // parse the markdown content
   const parsed = reader.parse(text)
   const walker = parsed.walker()
@@ -131,6 +136,17 @@ const extractFiles = (text, apiURL) => {
         files.push(`${apiURL}${node.destination}`);
       } else if (/^http/i.test(node.destination)) {
         files.push(node.destination);
+      }
+    } else if (event.entering && node.type === 'html_block' && node.literal) {
+      let match
+      const regex = /<img[^>]+src="?([^"\s]+)"?(.*)*\/>/g
+
+      while (match = regex.exec(node.literal)) {
+        if (/^\//.test(match[1])) {
+          files.push(`${apiURL}${match[1]}`);
+        } else if (/^http/i.test(match[1])) {
+          files.push(match[1]);
+        }
       }
     }
   }

--- a/helpers.js
+++ b/helpers.js
@@ -128,7 +128,7 @@ const extractFiles = (text, apiURL) => {
     return files;
   }
 
-  // parse the markdown content
+  // parse the markdown / richtext content
   const parsed = reader.parse(text)
   const walker = parsed.walker()
   let event, node
@@ -162,7 +162,7 @@ const extractFiles = (text, apiURL) => {
 const processFieldData = async (data, options) => {
   const { pluginOptions, nodeId, createNode, createNodeId, getCache } = options || {};
   const apiURL = pluginOptions?.apiURL;
-  const markdownImages = pluginOptions?.markdownImages?.typesToParse;
+  const inlineImages = pluginOptions?.inlineImages?.typesToParse;
   const __typename = data?.__typename;
   const output = JSON.parse(JSON.stringify(data));
 
@@ -180,9 +180,9 @@ const processFieldData = async (data, options) => {
       output.file = fileNode.id;
     }
   }
-  // Extract markdown files and download.
-  if (markdownImages?.[__typename]) {
-    await Promise.all((markdownImages[__typename] || []).map(async field => {
+  // Extract markdown / richtext files and download.
+  if (inlineImages?.[__typename]) {
+    await Promise.all((inlineImages[__typename] || []).map(async field => {
       const files = extractFiles(data[field], apiURL);
       if (files?.length) {
         await Promise.all(files.map(async (url, index) => {


### PR DESCRIPTION
Thanks for the plugin, this was actually exactly the sourcing plugin we needed for Strapi!

Most often we work with the TinyMCE editor in Strapi and thus have HTML output, but we want to use inline images as well. So I extended the extractFiles function to also be able to parse images from a HTML block.