### PR TITLE
Don't prefix api URL to downloads when not necessary

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -147,8 +147,9 @@ const processFieldData = async (data, options) => {
 
   // Extract files and download.
   if (__typename === 'UploadFile' && data.url) {
+    const url = /^\//.test(data.url) ? `${apiURL}${data.url}` : data.url;
     const fileNode = await createRemoteFileNode({
-      url: `${apiURL}${data.url}`,
+      url,
       parentNodeId: nodeId,
       createNode,
       createNodeId,


### PR DESCRIPTION
If using an uploads plugin such as S3, the uploaded file URL is already the full URL. It should only prepend `apiURL` when `data.url` begins with `/`