### PR TITLE
Fix for single collection type fetching

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -64,7 +64,8 @@ exports.sourceNodes = async ({
             variables: syncVariables,
             fetchPolicy: 'network-only',
           });
-          const nodes = syncResult?.data?.[field.name]?.data || [];
+          let nodes = syncResult?.data?.[field.name]?.data || [];
+          nodes = Array.isArray(nodes) ? nodes : [nodes];
           nodes.forEach(node => {
             const nodeId = createNodeId(`${NODE_TYPE}-${node.id}`);
             touchNode(getNode(nodeId));


### PR DESCRIPTION
I noticed errors on the syncResults query processing for the single collection types. This was caused because the data returned for a single collection type is not in array format, but a single object.