### PR TITLE
Improve image regex

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -144,7 +144,7 @@ const extractFiles = (text, apiURL) => {
       }
     } else if (event.entering && node.type === 'html_block' && node.literal) {
       let match
-      const regex = /<img[^>]+src="?([^"\s]+)"?(.*)*\/>/g
+      const regex = /<img[^>]+src="?([^"\s]+)"?\s*/gi
 
       while (match = regex.exec(node.literal)) {
         if (/^\//.test(match[1])) {


### PR DESCRIPTION
The image parsing from html_block elements sometimes hangs until infinity. It seemed due to an issue in the regex, I have made some modifications to improve it.