### PR TITLE
Fix query issue for publication state

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -47,9 +47,6 @@ exports.sourceNodes = async ({
       const UID = contentTypes?.[SOURCE_TYPE] || null;
       const variables = {
         ...operation?.variables,
-        ...pluginOptions?.preview && operation?.variables?.publicationState && {
-          publicationState: 'PREVIEW',
-        },
         ...lastFetched && operation?.variables?.updatedAt && {
           updatedAt: new Date(lastFetched).toISOString(),
         },


### PR DESCRIPTION
The publication state argument gives errors on queries for collection types that have the draf system turned off. It seems a false error, since the parameter is actually used in a subquery (in the example for the cases), but not on the main employees query.

Thus I have made some changes to not using an argument, but just directly pusing the publicationState value.

![Schermafbeelding 2022-06-29 om 13 08 06](https://user-images.githubusercontent.com/7559384/176422489-3b60ebe2-4150-4ba1-9c58-38181e80ce94.png)
